### PR TITLE
Add toPlainString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.5.0
+- Add toPlainString()
+
 ## 0.4.4
 - (Really) fix CI
 

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -368,11 +368,41 @@ class BigDecimal implements Comparable<BigDecimal> {
     }
 
     final intStr = intVal.abs().toString();
-    final b = StringBuffer(intVal.isNegative ? '-' : '');
-
     final adjusted = (intStr.length - 1) - scale;
+
     // Java's heuristic to avoid too many decimal places
     if (scale >= 0 && adjusted >= -6) {
+      return toPlainString();
+    }
+
+    // Exponential notation
+    final b = StringBuffer(intVal.isNegative ? '-' : '');
+    b.write(intStr[0]);
+    if (intStr.length > 1) {
+      b
+        ..write('.')
+        ..write(intStr.substring(1));
+    }
+    if (adjusted != 0) {
+      b.write('e');
+      if (adjusted > 0) {
+        b.write('+');
+      }
+      b.write(adjusted);
+    }
+
+    return b.toString();
+  }
+
+  String toPlainString() {
+    if (scale == 0) {
+      return intVal.toString();
+    }
+
+    final intStr = intVal.abs().toString();
+    final b = StringBuffer(intVal.isNegative ? '-' : '');
+
+    if (scale > 0) {
       if (intStr.length > scale) {
         final integerPart = intStr.substring(0, intStr.length - scale);
         b.write(integerPart);
@@ -387,20 +417,7 @@ class BigDecimal implements Comparable<BigDecimal> {
           ..write(intStr.padLeft(scale, '0'));
       }
     } else {
-      // Exponential notation
-      b.write(intStr[0]);
-      if (intStr.length > 1) {
-        b
-          ..write('.')
-          ..write(intStr.substring(1));
-      }
-      if (adjusted != 0) {
-        b.write('e');
-        if (adjusted > 0) {
-          b.write('+');
-        }
-        b.write(adjusted);
-      }
+      b.write(intStr.padRight(scale.abs() + intStr.length, '0'));
     }
 
     return b.toString();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: big_decimal
-version: 0.4.4
+version: 0.5.0
 description: >
   A bugless implementation of BigDecimal in Dart based on Java's BigDecimal
 

--- a/test/big_decimal_test.dart
+++ b/test/big_decimal_test.dart
@@ -493,6 +493,51 @@ void main() {
     ]),
   );
 
+  group(
+    'toPlainString()',
+    tabular((Object a, String result) {
+      expect(
+        a.dec.toPlainString(),
+        result,
+      );
+    }, [
+      // zeroes
+      tabCase(['0', '0']),
+      tabCase(['+0', '0']),
+      tabCase(['-0', '0']),
+      tabCase(['0.0', '0.0']),
+      tabCase(['+0.0', '0.0']),
+      tabCase(['-0.0', '0.0']),
+      tabCase(['.0', '0.0']),
+      tabCase(['+.0', '0.0']),
+      tabCase(['-.0', '0.0']),
+      // // no scale
+      tabCase(['1', '1']),
+      tabCase(['-1', '-1']),
+      // // with scale/decimal
+      tabCase(['1.0', '1.0']),
+      tabCase(['-1.0', '-1.0']),
+      tabCase(['.5', '0.5']),
+      tabCase(['-.5', '-0.5']),
+      // // with exponent input
+      tabCase(['3e-2', '0.03']),
+      tabCase(['3e-1', '0.3']),
+      tabCase(['-3e-1', '-0.3']),
+      tabCase(['3e0', '3']),
+      tabCase(['3.0e0', '3.0']),
+      tabCase(['3.0e-1', '0.30']),
+      tabCase(['-3.0e-1', '-0.30']),
+      tabCase(['3.0e1', '30']),
+      // without exponent toPlainString()
+      tabCase(['3e2', '300']),
+      tabCase(['123.456e-9', '0.000000123456']),
+      tabCase(['300e1', '3000']),
+      tabCase(['123.456e-8', '0.00000123456']),
+      tabCase(['0.00000001', '0.00000001']),
+      tabCase(['1e-8', '0.00000001']),
+    ]),
+  );
+
   group('hashcode', () {
     test('same for equal numbers', () {
       expect('1.0'.dec.hashCode, '1.0'.dec.hashCode);


### PR DESCRIPTION
It adds the capability of getting the string without scientific notation.

https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toPlainString--