### PR TITLE
Fix package score in pub.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.6.0
+- Fix static analysis issues
+- Add support for Dart 3
+- Remove internal members that were exposed to the API
+
 ## 0.5.0
 - Add toPlainString()
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,3 +4,7 @@ include: package:lints/recommended.yaml
 analyzer:
   exclude:
     - example/**/*.dart
+
+linter:
+  rules:
+    - public_member_api_docs

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,5 @@
+import 'package:big_decimal/big_decimal.dart';
+
+final decimal1 = BigDecimal.parse('1');
+final decimal2 = BigDecimal.parse('2');
+final decimal3 = decimal1 + decimal2; // 3

--- a/lib/big_decimal.dart
+++ b/lib/big_decimal.dart
@@ -1,1 +1,1 @@
-export 'src/big_decimal.dart' hide plusCode, dotCode, nineCode, zeroCode, minusCode, capitalECode, sumScale;
+export 'src/big_decimal.dart';

--- a/lib/big_decimal.dart
+++ b/lib/big_decimal.dart
@@ -1,1 +1,1 @@
-export 'src/big_decimal.dart';
+export 'src/big_decimal.dart' hide plusCode, dotCode, nineCode, zeroCode, minusCode, capitalECode;

--- a/lib/big_decimal.dart
+++ b/lib/big_decimal.dart
@@ -1,1 +1,1 @@
-export 'src/big_decimal.dart' hide plusCode, dotCode, nineCode, zeroCode, minusCode, capitalECode;
+export 'src/big_decimal.dart' hide plusCode, dotCode, nineCode, zeroCode, minusCode, capitalECode, sumScale;

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -117,10 +117,10 @@ class BigDecimal implements Comparable<BigDecimal> {
   final int scale;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is BigDecimal && compareTo(other) == 0;
 
-  bool exactlyEquals(dynamic other) =>
+  bool exactlyEquals(Object? other) =>
       other is BigDecimal && intVal == other.intVal && scale == other.scale;
 
   BigDecimal operator +(BigDecimal other) =>

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -62,7 +62,7 @@ class BigDecimal implements Comparable<BigDecimal> {
   /// a [BigDecimal] with a numerical value of 2
   static final two = BigDecimal.fromBigInt(BigInt.two);
 
-  static int nextNonDigit(String value, [int start = 0]) {
+  static int _nextNonDigit(String value, [int start = 0]) {
     var index = start;
     for (; index < value.length; index++) {
       final code = value.codeUnitAt(index);
@@ -102,7 +102,7 @@ class BigDecimal implements Comparable<BigDecimal> {
         break;
     }
 
-    nextIndex = nextNonDigit(value, index);
+    nextIndex = _nextNonDigit(value, index);
     final integerPart = '$sign${value.substring(index, nextIndex)}';
     index = nextIndex;
 
@@ -113,7 +113,7 @@ class BigDecimal implements Comparable<BigDecimal> {
     var decimalPart = '';
     if (value.codeUnitAt(index) == _dotCode) {
       index++;
-      nextIndex = nextNonDigit(value, index);
+      nextIndex = _nextNonDigit(value, index);
       decimalPart = value.substring(index, nextIndex);
       index = nextIndex;
 
@@ -324,14 +324,14 @@ class BigDecimal implements Comparable<BigDecimal> {
       return BigDecimal._(intVal: quotient, scale: scale);
     } else {
       if (preferredScale != scale) {
-        return createAndStripZerosForScale(quotient, scale, preferredScale);
+        return _createAndStripZerosForScale(quotient, scale, preferredScale);
       } else {
         return BigDecimal._(intVal: quotient, scale: scale);
       }
     }
   }
 
-  static BigDecimal createAndStripZerosForScale(
+  static BigDecimal _createAndStripZerosForScale(
     BigInt intVal,
     int scale,
     int preferredScale,

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -28,13 +28,13 @@ enum RoundingMode {
   UNNECESSARY,
 }
 
-const plusCode = 43;
-const minusCode = 45;
-const dotCode = 46;
-const smallECode = 101;
-const capitalECode = 69;
-const zeroCode = 48;
-const nineCode = 57;
+const _plusCode = 43;
+const _minusCode = 45;
+const _dotCode = 46;
+const _smallECode = 101;
+const _capitalECode = 69;
+const _zeroCode = 48;
+const _nineCode = 57;
 
 class BigDecimal implements Comparable<BigDecimal> {
   BigDecimal._({
@@ -57,7 +57,7 @@ class BigDecimal implements Comparable<BigDecimal> {
     var index = start;
     for (; index < value.length; index++) {
       final code = value.codeUnitAt(index);
-      if (code < zeroCode || code > nineCode) {
+      if (code < _zeroCode || code > _nineCode) {
         break;
       }
     }
@@ -78,11 +78,11 @@ class BigDecimal implements Comparable<BigDecimal> {
     var nextIndex = 0;
 
     switch (value.codeUnitAt(index)) {
-      case minusCode:
+      case _minusCode:
         sign = '-';
         index++;
         break;
-      case plusCode:
+      case _plusCode:
         index++;
         break;
       default:
@@ -98,7 +98,7 @@ class BigDecimal implements Comparable<BigDecimal> {
     }
 
     var decimalPart = '';
-    if (value.codeUnitAt(index) == dotCode) {
+    if (value.codeUnitAt(index) == _dotCode) {
       index++;
       nextIndex = nextNonDigit(value, index);
       decimalPart = value.substring(index, nextIndex);
@@ -113,8 +113,8 @@ class BigDecimal implements Comparable<BigDecimal> {
     }
 
     switch (value.codeUnitAt(index)) {
-      case smallECode:
-      case capitalECode:
+      case _smallECode:
+      case _capitalECode:
         index++;
         final exponent = int.parse(value.substring(index));
         return BigDecimal._(
@@ -196,11 +196,11 @@ class BigDecimal implements Comparable<BigDecimal> {
       return BigDecimal._(intVal: BigInt.zero, scale: newScale);
     } else {
       if (newScale > scale) {
-        final drop = sumScale(newScale, -scale);
+        final drop = _sumScale(newScale, -scale);
         final intResult = intVal * BigInt.from(10).pow(drop);
         return BigDecimal._(intVal: intResult, scale: newScale);
       } else {
-        final drop = sumScale(scale, -newScale);
+        final drop = _sumScale(scale, -newScale);
         return _divideAndRound(intVal, BigInt.from(10).pow(drop), newScale,
             roundingMode, newScale);
       }
@@ -240,14 +240,14 @@ class BigDecimal implements Comparable<BigDecimal> {
     if (dividend == BigInt.zero) {
       return BigDecimal._(intVal: BigInt.zero, scale: scale);
     }
-    if (sumScale(scale, divisorScale) > dividendScale) {
+    if (_sumScale(scale, divisorScale) > dividendScale) {
       final newScale = scale + divisorScale;
       final raise = newScale - dividendScale;
       final scaledDividend = dividend * BigInt.from(10).pow(raise);
       return _divideAndRound(
           scaledDividend, divisor, scale, roundingMode, scale);
     } else {
-      final newScale = sumScale(dividendScale, -scale);
+      final newScale = _sumScale(dividendScale, -scale);
       final raise = newScale - divisorScale;
       final scaledDivisor = divisor * BigInt.from(10).pow(raise);
       return _divideAndRound(
@@ -301,7 +301,7 @@ class BigDecimal implements Comparable<BigDecimal> {
         break;
       }
       intValMut = intValMut ~/ ten;
-      scaleMut = sumScale(scaleMut, -1);
+      scaleMut = _sumScale(scaleMut, -1);
     }
 
     return BigDecimal._(intVal: intValMut, scale: scaleMut);
@@ -436,7 +436,7 @@ class BigDecimal implements Comparable<BigDecimal> {
   }
 }
 
-int sumScale(int scaleA, int scaleB) {
+int _sumScale(int scaleA, int scaleB) {
   // TODO: We need to check for overflows here
   return scaleA + scaleB;
 }

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -334,11 +334,6 @@ class BigDecimal implements Comparable<BigDecimal> {
     }
   }
 
-  static int sumScale(int scaleA, int scaleB) {
-    // TODO: We need to check for overflows here
-    return scaleA + scaleB;
-  }
-
   @override
   int compareTo(BigDecimal other) {
     if (scale == other.scale) {
@@ -422,4 +417,9 @@ class BigDecimal implements Comparable<BigDecimal> {
 
     return b.toString();
   }
+}
+
+int sumScale(int scaleA, int scaleB) {
+  // TODO: We need to check for overflows here
+  return scaleA + scaleB;
 }

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -152,24 +152,19 @@ class BigDecimal implements Comparable<BigDecimal> {
   final int scale;
 
   @override
-  bool operator ==(Object other) =>
-      other is BigDecimal && compareTo(other) == 0;
+  bool operator ==(Object other) => other is BigDecimal && compareTo(other) == 0;
 
   /// compares this with [other] for both value and scale
-  bool exactlyEquals(Object? other) =>
-      other is BigDecimal && intVal == other.intVal && scale == other.scale;
+  bool exactlyEquals(Object? other) => other is BigDecimal && intVal == other.intVal && scale == other.scale;
 
   /// adds this to [other]
-  BigDecimal operator +(BigDecimal other) =>
-      _add(intVal, other.intVal, scale, other.scale);
+  BigDecimal operator +(BigDecimal other) => _add(intVal, other.intVal, scale, other.scale);
 
   /// multiply this with [other]
-  BigDecimal operator *(BigDecimal other) =>
-      BigDecimal._(intVal: intVal * other.intVal, scale: scale + other.scale);
+  BigDecimal operator *(BigDecimal other) => BigDecimal._(intVal: intVal * other.intVal, scale: scale + other.scale);
 
   /// subtracts this to [other]
-  BigDecimal operator -(BigDecimal other) =>
-      _add(intVal, -other.intVal, scale, other.scale);
+  BigDecimal operator -(BigDecimal other) => _add(intVal, -other.intVal, scale, other.scale);
 
   /// Whether this is less than [other].
   bool operator <(BigDecimal other) => compareTo(other) < 0;
@@ -198,8 +193,7 @@ class BigDecimal implements Comparable<BigDecimal> {
     RoundingMode roundingMode = RoundingMode.UNNECESSARY,
     int? scale,
   }) =>
-      _divide(intVal, this.scale, divisor.intVal, divisor.scale,
-          scale ?? this.scale, roundingMode);
+      _divide(intVal, this.scale, divisor.intVal, divisor.scale, scale ?? this.scale, roundingMode);
 
   /// this to the power of [n]
   BigDecimal pow(int n) {
@@ -208,13 +202,11 @@ class BigDecimal implements Comparable<BigDecimal> {
       final newScale = scale * n;
       return BigDecimal._(intVal: intVal.pow(n), scale: newScale);
     }
-    throw Exception(
-        'Invalid operation: Exponent should be between 0 and 999999999');
+    throw Exception('Invalid operation: Exponent should be between 0 and 999999999');
   }
 
   /// returns this as a [double]
-  double toDouble() =>
-      intVal.toDouble() / BigInt.from(10).pow(scale).toDouble();
+  double toDouble() => intVal.toDouble() / BigInt.from(10).pow(scale).toDouble();
 
   /// returns this as a [BigInt] with the desired [roundingMode]
   ///
@@ -227,8 +219,7 @@ class BigDecimal implements Comparable<BigDecimal> {
   ///
   /// Throws [Exception] if rounding is [RoundingMode.UNNECESSARY] but rounding
   /// is actually necessary.
-  int toInt({RoundingMode roundingMode = RoundingMode.UNNECESSARY}) =>
-      toBigInt(roundingMode: roundingMode).toInt();
+  int toInt({RoundingMode roundingMode = RoundingMode.UNNECESSARY}) => toBigInt(roundingMode: roundingMode).toInt();
 
   /// returns a new [BigDecimal] with the desired [newScale]. May round by
   /// [roundingMode].
@@ -250,8 +241,7 @@ class BigDecimal implements Comparable<BigDecimal> {
         return BigDecimal._(intVal: intResult, scale: newScale);
       } else {
         final drop = _sumScale(scale, -newScale);
-        return _divideAndRound(intVal, BigInt.from(10).pow(drop), newScale,
-            roundingMode, newScale);
+        return _divideAndRound(intVal, BigInt.from(10).pow(drop), newScale, roundingMode, newScale);
       }
     }
   }
@@ -264,8 +254,7 @@ class BigDecimal implements Comparable<BigDecimal> {
     return intVal.abs().compareTo(BigInt.from(10).pow(r)) < 0 ? r : r + 1;
   }
 
-  static BigDecimal _add(
-      BigInt intValA, BigInt intValB, int scaleA, int scaleB) {
+  static BigDecimal _add(BigInt intValA, BigInt intValB, int scaleA, int scaleB) {
     final scaleDiff = scaleA - scaleB;
     if (scaleDiff == 0) {
       return BigDecimal._(intVal: intValA + intValB, scale: scaleA);
@@ -293,14 +282,12 @@ class BigDecimal implements Comparable<BigDecimal> {
       final newScale = scale + divisorScale;
       final raise = newScale - dividendScale;
       final scaledDividend = dividend * BigInt.from(10).pow(raise);
-      return _divideAndRound(
-          scaledDividend, divisor, scale, roundingMode, scale);
+      return _divideAndRound(scaledDividend, divisor, scale, roundingMode, scale);
     } else {
       final newScale = _sumScale(dividendScale, -scale);
       final raise = newScale - divisorScale;
       final scaledDivisor = divisor * BigInt.from(10).pow(raise);
-      return _divideAndRound(
-          dividend, scaledDivisor, scale, roundingMode, scale);
+      return _divideAndRound(dividend, scaledDivisor, scale, roundingMode, scale);
     }
   }
 
@@ -315,10 +302,8 @@ class BigDecimal implements Comparable<BigDecimal> {
     final remainder = dividend.remainder(divisor).abs();
     final quotientPositive = dividend.sign == divisor.sign;
     if (remainder != BigInt.zero) {
-      if (_needIncrement(
-          divisor, roundingMode, quotientPositive, quotient, remainder)) {
-        final intResult =
-            quotient + (quotientPositive ? BigInt.one : -BigInt.one);
+      if (_needIncrement(divisor, roundingMode, quotientPositive, quotient, remainder)) {
+        final intResult = quotient + (quotientPositive ? BigInt.one : -BigInt.one);
         return BigDecimal._(intVal: intResult, scale: scale);
       }
       return BigDecimal._(intVal: quotient, scale: scale);
@@ -363,8 +348,7 @@ class BigDecimal implements Comparable<BigDecimal> {
     BigInt quotient,
     BigInt remainder,
   ) {
-    final remainderComparisonToHalfDivisor =
-        (remainder * BigInt.from(2)).compareTo(divisor);
+    final remainderComparisonToHalfDivisor = (remainder * BigInt.from(2)).compareTo(divisor);
     switch (roundingMode) {
       case RoundingMode.UNNECESSARY:
         throw Exception('Rounding necessary');

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -1,13 +1,30 @@
+// enum is using screaming snake case due to a direct migration from java
 // ignore_for_file: constant_identifier_names
 
+/// rounding mode used when doing operations on a [BigDecimal]
 enum RoundingMode {
+  /// away from zero
   UP,
+
+  /// towards zero
   DOWN,
+
+  /// towards +infinity
   CEILING,
+
+  /// towards -infinity
   FLOOR,
+
+  /// away from zero if remainder comparison to half divisor is even
   HALF_UP,
+
+  /// towards zero if remainder comparison to half divisor is even
   HALF_DOWN,
+
+  /// towards zero if remainder comparison to half divisor is even and [BigDecimal] is odd
   HALF_EVEN,
+
+  /// does not round at all. Throws if not exact and needs rounding
   UNNECESSARY,
 }
 

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -49,9 +49,9 @@ class BigDecimal implements Comparable<BigDecimal> {
     );
   }
 
-  static BigDecimal zero = BigDecimal.fromBigInt(BigInt.zero);
-  static BigDecimal one = BigDecimal.fromBigInt(BigInt.one);
-  static BigDecimal two = BigDecimal.fromBigInt(BigInt.two);
+  static final zero = BigDecimal.fromBigInt(BigInt.zero);
+  static final one = BigDecimal.fromBigInt(BigInt.one);
+  static final two = BigDecimal.fromBigInt(BigInt.two);
 
   static int nextNonDigit(String value, [int start = 0]) {
     var index = start;

--- a/lib/src/big_decimal.dart
+++ b/lib/src/big_decimal.dart
@@ -152,19 +152,24 @@ class BigDecimal implements Comparable<BigDecimal> {
   final int scale;
 
   @override
-  bool operator ==(Object other) => other is BigDecimal && compareTo(other) == 0;
+  bool operator ==(Object other) =>
+      other is BigDecimal && compareTo(other) == 0;
 
   /// compares this with [other] for both value and scale
-  bool exactlyEquals(Object? other) => other is BigDecimal && intVal == other.intVal && scale == other.scale;
+  bool exactlyEquals(Object? other) =>
+      other is BigDecimal && intVal == other.intVal && scale == other.scale;
 
   /// adds this to [other]
-  BigDecimal operator +(BigDecimal other) => _add(intVal, other.intVal, scale, other.scale);
+  BigDecimal operator +(BigDecimal other) =>
+      _add(intVal, other.intVal, scale, other.scale);
 
   /// multiply this with [other]
-  BigDecimal operator *(BigDecimal other) => BigDecimal._(intVal: intVal * other.intVal, scale: scale + other.scale);
+  BigDecimal operator *(BigDecimal other) =>
+      BigDecimal._(intVal: intVal * other.intVal, scale: scale + other.scale);
 
   /// subtracts this to [other]
-  BigDecimal operator -(BigDecimal other) => _add(intVal, -other.intVal, scale, other.scale);
+  BigDecimal operator -(BigDecimal other) =>
+      _add(intVal, -other.intVal, scale, other.scale);
 
   /// Whether this is less than [other].
   bool operator <(BigDecimal other) => compareTo(other) < 0;
@@ -193,7 +198,8 @@ class BigDecimal implements Comparable<BigDecimal> {
     RoundingMode roundingMode = RoundingMode.UNNECESSARY,
     int? scale,
   }) =>
-      _divide(intVal, this.scale, divisor.intVal, divisor.scale, scale ?? this.scale, roundingMode);
+      _divide(intVal, this.scale, divisor.intVal, divisor.scale,
+          scale ?? this.scale, roundingMode);
 
   /// this to the power of [n]
   BigDecimal pow(int n) {
@@ -202,11 +208,13 @@ class BigDecimal implements Comparable<BigDecimal> {
       final newScale = scale * n;
       return BigDecimal._(intVal: intVal.pow(n), scale: newScale);
     }
-    throw Exception('Invalid operation: Exponent should be between 0 and 999999999');
+    throw Exception(
+        'Invalid operation: Exponent should be between 0 and 999999999');
   }
 
   /// returns this as a [double]
-  double toDouble() => intVal.toDouble() / BigInt.from(10).pow(scale).toDouble();
+  double toDouble() =>
+      intVal.toDouble() / BigInt.from(10).pow(scale).toDouble();
 
   /// returns this as a [BigInt] with the desired [roundingMode]
   ///
@@ -219,7 +227,8 @@ class BigDecimal implements Comparable<BigDecimal> {
   ///
   /// Throws [Exception] if rounding is [RoundingMode.UNNECESSARY] but rounding
   /// is actually necessary.
-  int toInt({RoundingMode roundingMode = RoundingMode.UNNECESSARY}) => toBigInt(roundingMode: roundingMode).toInt();
+  int toInt({RoundingMode roundingMode = RoundingMode.UNNECESSARY}) =>
+      toBigInt(roundingMode: roundingMode).toInt();
 
   /// returns a new [BigDecimal] with the desired [newScale]. May round by
   /// [roundingMode].
@@ -241,7 +250,8 @@ class BigDecimal implements Comparable<BigDecimal> {
         return BigDecimal._(intVal: intResult, scale: newScale);
       } else {
         final drop = _sumScale(scale, -newScale);
-        return _divideAndRound(intVal, BigInt.from(10).pow(drop), newScale, roundingMode, newScale);
+        return _divideAndRound(intVal, BigInt.from(10).pow(drop), newScale,
+            roundingMode, newScale);
       }
     }
   }
@@ -254,7 +264,8 @@ class BigDecimal implements Comparable<BigDecimal> {
     return intVal.abs().compareTo(BigInt.from(10).pow(r)) < 0 ? r : r + 1;
   }
 
-  static BigDecimal _add(BigInt intValA, BigInt intValB, int scaleA, int scaleB) {
+  static BigDecimal _add(
+      BigInt intValA, BigInt intValB, int scaleA, int scaleB) {
     final scaleDiff = scaleA - scaleB;
     if (scaleDiff == 0) {
       return BigDecimal._(intVal: intValA + intValB, scale: scaleA);
@@ -282,12 +293,14 @@ class BigDecimal implements Comparable<BigDecimal> {
       final newScale = scale + divisorScale;
       final raise = newScale - dividendScale;
       final scaledDividend = dividend * BigInt.from(10).pow(raise);
-      return _divideAndRound(scaledDividend, divisor, scale, roundingMode, scale);
+      return _divideAndRound(
+          scaledDividend, divisor, scale, roundingMode, scale);
     } else {
       final newScale = _sumScale(dividendScale, -scale);
       final raise = newScale - divisorScale;
       final scaledDivisor = divisor * BigInt.from(10).pow(raise);
-      return _divideAndRound(dividend, scaledDivisor, scale, roundingMode, scale);
+      return _divideAndRound(
+          dividend, scaledDivisor, scale, roundingMode, scale);
     }
   }
 
@@ -302,8 +315,10 @@ class BigDecimal implements Comparable<BigDecimal> {
     final remainder = dividend.remainder(divisor).abs();
     final quotientPositive = dividend.sign == divisor.sign;
     if (remainder != BigInt.zero) {
-      if (_needIncrement(divisor, roundingMode, quotientPositive, quotient, remainder)) {
-        final intResult = quotient + (quotientPositive ? BigInt.one : -BigInt.one);
+      if (_needIncrement(
+          divisor, roundingMode, quotientPositive, quotient, remainder)) {
+        final intResult =
+            quotient + (quotientPositive ? BigInt.one : -BigInt.one);
         return BigDecimal._(intVal: intResult, scale: scale);
       }
       return BigDecimal._(intVal: quotient, scale: scale);
@@ -348,7 +363,8 @@ class BigDecimal implements Comparable<BigDecimal> {
     BigInt quotient,
     BigInt remainder,
   ) {
-    final remainderComparisonToHalfDivisor = (remainder * BigInt.from(2)).compareTo(divisor);
+    final remainderComparisonToHalfDivisor =
+        (remainder * BigInt.from(2)).compareTo(divisor);
     switch (roundingMode) {
       case RoundingMode.UNNECESSARY:
         throw Exception('Rounding necessary');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,5 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  lints: ^2.0.1
+  lints: ^5.1.1
   test: ^1.17.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: big_decimal
-version: 0.5.0
+version: 0.6.0
 description: >
   A bugless implementation of BigDecimal in Dart based on Java's BigDecimal
 
 repository: https://github.com/bugless/big-decimal
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dev_dependencies:
   lints: ^5.1.1

--- a/test/big_decimal_test.dart
+++ b/test/big_decimal_test.dart
@@ -287,9 +287,9 @@ void main() {
           String down,
           String ceiling,
           String floor,
-          String half_up,
-          String half_down,
-          String half_even,
+          String halfUp,
+          String halfDown,
+          String halfEven,
           Object unnecessary,
         ) {
           BigDecimal round(RoundingMode mode) =>
@@ -300,11 +300,11 @@ void main() {
               reason: 'CEILING');
           expect(round(RoundingMode.FLOOR), exactly(floor.dec),
               reason: 'FLOOR');
-          expect(round(RoundingMode.HALF_UP), exactly(half_up.dec),
+          expect(round(RoundingMode.HALF_UP), exactly(halfUp.dec),
               reason: 'HALF_UP');
-          expect(round(RoundingMode.HALF_DOWN), exactly(half_down.dec),
+          expect(round(RoundingMode.HALF_DOWN), exactly(halfDown.dec),
               reason: 'HALF_DOWN');
-          expect(round(RoundingMode.HALF_EVEN), exactly(half_even.dec),
+          expect(round(RoundingMode.HALF_EVEN), exactly(halfEven.dec),
               reason: 'HALF_EVEN');
           if (unnecessary is String) {
             expect(round(RoundingMode.UNNECESSARY), exactly(unnecessary.dec),


### PR DESCRIPTION
Creating this PR to improve its score in pub.dev by applying the following changes:
1. Removing usage of `dynamic` types, which was causing a warning on the equality operator
2. Adding doc comments on public members of the API
3. Making some members private. I believe they were exposed to the API by mistake
4. Updating the `lints` dev dependency. This is not a breaking change because dev deps are not carried over to consumers of this package
5. Enabled `public_member_api_docs` to avoid future problems
6. Marked Dart 3 supported on `pubspec`
7. Added a bare minimal example

**Note**: even though I removed public members (see number 3), I bumped the version from 0.5 to 0.6, which is considered a *major* upgrade (breaking changes allowed)